### PR TITLE
Changed plugin ID to work with API 6.0.0

### DIFF
--- a/src/main/java/net/mineguild/minecraft/treedestroyage/TreeDestroyage.java
+++ b/src/main/java/net/mineguild/minecraft/treedestroyage/TreeDestroyage.java
@@ -32,7 +32,7 @@ import java.util.*;
 
 import static org.spongepowered.api.command.args.GenericArguments.*;
 
-@Plugin(id = "net.mineguild.minecraft.treedestroyage", description = "A plugin that allows to log trees quickly!", name = "TreeDestroyage", version = "0.11-DEV-API5.0.0")
+@Plugin(id = "treedestroyage", description = "A plugin that allows to log trees quickly!", name = "TreeDestroyage", version = "0.11-DEV-API5.0.0")
 public class TreeDestroyage {
 
     //@Inject


### PR DESCRIPTION
The previous ID threw the following exception with the new API:

`[17:44:24 ERROR] [Sponge]: Skipping plugin with invalid plugin ID 'net.mineguild.minecraft.treedestroyage' from mods\TreeDestroyage-0.11-DEV-API5.0.0-37-all (1).jar. Plugin IDs should be lowercase, and only contain characters from a-z, dashes or underscores, start with a lowercase letter, and not exceed 64 characters.`